### PR TITLE
Do not prefix empty strings.

### DIFF
--- a/inc/wpml-compatibility-test-tools.functions.php
+++ b/inc/wpml-compatibility-test-tools.functions.php
@@ -12,6 +12,10 @@
 function wpml_ctt_prepare_string( $template, $string, $lang ) {
 	global $sitepress;
 
+	if ( empty( $string ) ) {
+		return $string;
+	}
+
 	$template = str_replace( '%original_string%', $string, $template );
 
 	$language_details = $sitepress->get_language_details( $lang );


### PR DESCRIPTION
Examples: an emoty tagline, an empty widget title or an empty content.
In these cases, we dont apply the template.