### PR TITLE
Custom Fields Translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Multilingual Tools are set of tools related to [WPML](https://wpml.org) plugin b
 -   Auto generate strings for translations
 -   Add language information to post duplicate
 -   Generate WPML config file ( wpml-config.xml )
+-   Assist with Custom Fields translation preferences
 
 ## Requirements
 
@@ -17,7 +18,6 @@ For this plugin to work you will need:
 
 -   WPML Multilingual CMS
 -   WPML String Translation
--   WPML Translation Management
 
 All plugins can be downloaded from [WPML.org](https://wpml.org)
 

--- a/inc/class-mltools-custom-fields-translation.php
+++ b/inc/class-mltools-custom-fields-translation.php
@@ -1,0 +1,144 @@
+<?php
+
+class MLTools_Custom_Fields_Translation {
+	public function __construct() {
+		add_action( 'wp_ajax_wpml_cf_generate_xml', array( $this, 'wpml_cf_generate_xml' ) );
+	}
+
+	public function get_custom_fields() {
+		global $wpdb;
+
+		// We don't need system fields starting with an underscore "_"
+
+		$meta_keys = $wpdb->get_results( "SELECT DISTINCT meta_key FROM $wpdb->postmeta WHERE meta_key NOT LIKE '\_%' ORDER BY meta_key ASC" );
+
+		$custom_fields = array();
+
+		foreach ( $meta_keys as $meta_key ) {
+			$custom_fields[] = $meta_key->meta_key;
+		}
+
+		// We need to exclude the fields with defined translation preference in WPML
+
+		$excluded_custom_fields = array();
+
+		$settings = get_option( 'icl_sitepress_settings' );
+
+		if ( ! empty( $settings['translation-management']['custom_fields_translation'] ) ) {
+			foreach ( $settings['translation-management']['custom_fields_translation'] as $custom_field => $value ) {
+				$excluded_custom_fields[] = $custom_field;
+			}
+		}
+
+		// Providing a filter to add more fields to be excluded
+
+		/**
+		 * Example
+		 *
+		 * function my_custom_excluded_fields($excluded_fields) {
+		 * $excluded_fields[] = 'my_custom_field_1';
+		 * $excluded_fields[] = 'my_custom_field_2';
+		 * return $excluded_fields;
+		 * }
+		 * add_filter('wpml_custom_fields_helper_excluded_custom_fields', 'my_custom_excluded_fields');
+		 */
+
+		$excluded_custom_fields = apply_filters( 'wpml_custom_fields_helper_excluded_custom_fields', $excluded_custom_fields );
+
+		$custom_fields = array_diff( $custom_fields, $excluded_custom_fields );
+
+		// We don't need these fields wpml_, attribute_pa-, acfml, etc..
+
+		$excluded_prefixes = [ 'acfml', 'attribute_pa', 'wpml', 'wpform' ];
+
+		$custom_fields = array_filter( $custom_fields, function ( $field ) use ( $excluded_prefixes ) {
+			foreach ( $excluded_prefixes as $prefix ) {
+				if ( strpos( $field, $prefix ) === 0 ) {
+					return false;
+				}
+			}
+
+			return true;
+		} );
+
+
+		return $custom_fields;
+	}
+
+	public function determine_translation_preference() {
+
+		global $wpdb;
+
+		$custom_fields           = $this->get_custom_fields();
+		$translation_preferences = array();
+
+		foreach ( $custom_fields as $custom_field ) {
+
+			$value = $wpdb->get_var( $wpdb->prepare( "SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = %s LIMIT 1", $custom_field ) );
+
+			// Check if value is numeric, a date string, or specific strings
+
+			$date        = DateTime::createFromFormat( 'd-m-Y', $value );
+			$date_errors = DateTime::getLastErrors();
+
+			// These values should be copied to translations
+			$copy_values = [ 'yes', 'no', 'on', 'off', 'true', 'false', 'default' ];
+
+			// Is it a hash-like string? Something like ffd4rf34d should be set to copy
+			$isHashString = strlen( $value ) > 5 && preg_match( '/\d/', $value ) && preg_match( '/[a-zA-Z]/', $value ) && strpos( $value, ' ' ) === false;
+
+
+			if ( is_numeric( $value ) ||
+			     ( $date && $date_errors['warning_count'] == 0 && $date_errors['error_count'] == 0 ) ||
+			     in_array( $value, $copy_values ) ||
+			     is_serialized( $value ) ||
+			     null ||
+			     empty( $value ) ||
+			     // Check if the value is an email or a URL.
+			     filter_var( $value, FILTER_VALIDATE_EMAIL ) ||
+			     strpos( $value, 'http' ) !== false
+			     || $isHashString
+			) {
+				$translation_preferences[ $custom_field ] = 'copy';
+			} else {
+				$translation_preferences[ $custom_field ] = 'translate';
+			}
+		}
+
+		return $translation_preferences;
+	}
+
+	public function wpml_cf_generate_xml() {
+
+		check_ajax_referer( 'wpml_cf_nonce', 'wpml_cf_nonce' );
+
+		// Prepare the base of your XML
+		$wpml_config = '<wpml-config><custom-fields>';
+		foreach ( $_POST['cf'] as $custom_field => $preference ) {
+			$custom_field = sanitize_text_field( $custom_field );
+			$preference   = sanitize_text_field( $preference );
+
+			$wpml_config .= "<custom-field action=\"$preference\">$custom_field</custom-field>";
+		}
+
+		$wpml_config .= '</custom-fields></wpml-config>';
+
+		// Create the XML file
+		$formatted_xml = $this->format_xml( $wpml_config );
+
+		echo $formatted_xml;
+
+		wp_die();
+	}
+
+
+	public function format_xml( $xml_string ) {
+		$dom                     = new DOMDocument;
+		$dom->preserveWhiteSpace = false;
+		$dom->loadXML( $xml_string );
+		$dom->formatOutput = true;
+
+		return htmlentities( $dom->saveXML( $dom->documentElement ) );
+	}
+
+}

--- a/inc/class-mltools-custom-fields-translation.php
+++ b/inc/class-mltools-custom-fields-translation.php
@@ -78,14 +78,16 @@ class MLTools_Custom_Fields_Translation {
 
 			// Check if value is numeric, a date string, or specific strings
 
-			$date        = DateTime::createFromFormat( 'd-m-Y', $value );
-			$date_errors = DateTime::getLastErrors();
+			if ( $value ) {
+				$date        = DateTime::createFromFormat( 'd-m-Y', $value );
+				$date_errors = DateTime::getLastErrors();
+			}
 
 			// These values should be copied to translations
 			$copy_values = [ 'yes', 'no', 'on', 'off', 'true', 'false', 'default' ];
 
 			// Is it a hash-like string? Something like ffd4rf34d should be set to copy
-			$isHashString = strlen( $value ) > 5 && preg_match( '/\d/', $value ) && preg_match( '/[a-zA-Z]/', $value ) && strpos( $value, ' ' ) === false;
+			$isHashString = $value && strlen( $value ) > 5 && preg_match( '/\d/', $value ) && preg_match( '/[a-zA-Z]/', $value ) && strpos( $value, ' ' ) === false;
 
 
 			if ( is_numeric( $value ) ||

--- a/inc/wpml-compatibility-test-tools.class.php
+++ b/inc/wpml-compatibility-test-tools.class.php
@@ -10,6 +10,10 @@ class WPML_Compatibility_Test_Tools extends WPML_Compatibility_Test_Tools_Base {
 
 	public function init() {
 
+		if (class_exists('MLTools_Custom_Fields_Translation')) {
+			new MLTools_Custom_Fields_Translation();
+		}
+
 		// Generate XML
 		if ( isset( $_POST['wctt-generator-submit'] ) && check_admin_referer( 'wctt-generate', '_wctt_mighty_nonce' ) ) {
 			add_action( 'wp_loaded', array( $this, 'generate_xml' ) );
@@ -318,6 +322,10 @@ class WPML_Compatibility_Test_Tools extends WPML_Compatibility_Test_Tools_Base {
 			$this,
 			'load_template'
 		) );
+		add_submenu_page( 'mt', __( 'Custom Fields Translation', 'wpml-compatibility-test-tools' ), __( 'Custom Fields Translation', 'wpml-compatibility-test-tools' ), 'manage_options', 'cf-translations', array(
+			$this,
+			'load_template'
+		) );
 	}
 
 	/**
@@ -340,6 +348,10 @@ class WPML_Compatibility_Test_Tools extends WPML_Compatibility_Test_Tools_Base {
 
 			case 'multilingual-tools_page_mt-generator' :
 				require WPML_CTT_ABS_PATH . 'menus/settings/generator.php';
+				break;
+
+			case 'multilingual-tools_page_cf-translations' :
+				require WPML_CTT_ABS_PATH . 'menus/settings/custom-fields-translation.php';
 				break;
 		}
 	}
@@ -367,6 +379,26 @@ class WPML_Compatibility_Test_Tools extends WPML_Compatibility_Test_Tools_Base {
 				'ajax_url' => admin_url( 'admin-ajax.php' ),
 				'labels'   => $this->js_labels()
 			) );
+
+		}
+
+		elseif ($hook == 'multilingual-tools_page_cf-translations') {
+
+			wp_enqueue_script(
+				'wpml_custom_fields_helper_script',
+				WPML_CTT_PLUGIN_URL . '/res/js/mt-script.js',
+				array( 'jquery' ),
+				false,
+				true
+			);
+
+			wp_localize_script(
+				'wpml_custom_fields_helper_script',
+				'wpmlData',
+				array(
+					'ajax_url' => admin_url( 'admin-ajax.php' ),
+				)
+			);
 
 		}
 	}

--- a/inc/wpml-compatibility-test-tools.class.php
+++ b/inc/wpml-compatibility-test-tools.class.php
@@ -322,7 +322,7 @@ class WPML_Compatibility_Test_Tools extends WPML_Compatibility_Test_Tools_Base {
 			$this,
 			'load_template'
 		) );
-		add_submenu_page( 'mt', __( 'Custom Fields Translation', 'wpml-compatibility-test-tools' ), __( 'Custom Fields Translation', 'wpml-compatibility-test-tools' ), 'manage_options', 'cf-translations', array(
+		add_submenu_page( 'mt', __( 'Custom Field Settings Helper', 'wpml-compatibility-test-tools' ), __( 'Custom Field Settings Helper', 'wpml-compatibility-test-tools' ), 'manage_options', 'cf-translations', array(
 			$this,
 			'load_template'
 		) );

--- a/menus/settings/custom-fields-translation.php
+++ b/menus/settings/custom-fields-translation.php
@@ -6,7 +6,7 @@ $translation_preferences      = $mt_custom_fields_translation->determine_transla
 ?>
 <div class="wrap">
 
-	<h2><?php _e( 'Custom Fields Translation Helper', 'wpml-compatibility-test-tools' ); ?></h2>
+	<h2><?php _e( 'Custom Field Settings Helper', 'wpml-compatibility-test-tools' ); ?></h2>
 
 	<div class="description">
 		<p><?php echo sprintf( __( 'The following table shows the custom fields with no translation preferences and suggests a translation preference for each field. You can review them and generate the XML. Once the XML is generated, you can copy it and paste it in the <a href="%s">Custom XML Configuration</a> tab in WPML.', 'wpml-compatibility-test-tools' ), esc_url( admin_url( 'admin.php?page=tm%2Fmenu%2Fsettings&sm=custom-xml-config' ) ) ); ?></p>
@@ -62,7 +62,7 @@ $translation_preferences      = $mt_custom_fields_translation->determine_transla
 
 						// If the value length is greater than the defined maximum length,
 						// cut it down and append '...' to indicate that it's truncated
-						if ( strlen( $value ) > $maxLength ) {
+						if ( $value && strlen( $value ) > $maxLength ) {
 							$value = substr( $value, 0, $maxLength ) . "...";
 						} elseif ( empty( $value ) ) {
 							$value = 'N/A';

--- a/menus/settings/custom-fields-translation.php
+++ b/menus/settings/custom-fields-translation.php
@@ -1,0 +1,112 @@
+<?php
+require_once WPML_CTT_PATH . '/inc/class-mltools-custom-fields-translation.php';
+$mt_custom_fields_translation = new MLTools_Custom_Fields_Translation();
+$custom_fields                = $mt_custom_fields_translation->get_custom_fields();
+$translation_preferences      = $mt_custom_fields_translation->determine_translation_preference();
+?>
+<div class="wrap">
+
+	<h2><?php _e( 'Custom Fields Translation Helper', 'wpml-compatibility-test-tools' ); ?></h2>
+
+	<div class="description">
+		<p><?php echo sprintf( __( 'The following table shows the custom fields with no translation preferences and suggests a translation preference for each field. You can review them and generate the XML. Once the XML is generated, you can copy it and paste it in the <a href="%s">Custom XML Configuration</a> tab in WPML.', 'wpml-compatibility-test-tools' ), esc_url( admin_url( 'admin.php?page=tm%2Fmenu%2Fsettings&sm=custom-xml-config' ) ) ); ?></p>
+	</div>
+
+	<form id="wpml-cf-form">
+		<table class="widefat">
+			<?php if ( $custom_fields ): ?>
+			<thead>
+			<tr>
+				<th><?php esc_html_e( 'Custom fields', 'wpml-compatibility-test-tools' ); ?></th>
+				<th><?php esc_html_e( "Don't translate", 'wpml-compatibility-test-tools' ); ?></th>
+				<th><?php esc_html_e( "Copy", 'wpml-compatibility-test-tools' ); ?></th>
+				<th><?php esc_html_e( "Copy once", 'wpml-compatibility-test-tools' ); ?></th>
+				<th><?php esc_html_e( "Translate", 'wpml-compatibility-test-tools' ); ?></th>
+				<th><?php esc_html_e( "Sample", 'wpml-compatibility-test-tools' ); ?></th>
+			</tr>
+			</thead>
+			<tbody class="wctt">
+			<?php foreach ( $translation_preferences as $custom_field => $translation_preference ): ?>
+				<tr>
+					<td>
+						<label>
+							<?php echo esc_html( $custom_field ); ?>
+						</label>
+					</td>
+					<td title="<?php esc_attr_e( "Don't translate", 'wpml-compatibility-test-tools' ); ?>">
+						<input id="cf_0_<?php echo esc_attr( $custom_field ); ?>" type="radio"
+						       name="cf[<?php echo esc_attr( $custom_field ); ?>]" value="ignore"/>
+					</td>
+					<td title="<?php esc_attr_e( "Copy", 'wpml-compatibility-test-tools' ); ?>">
+						<input id="cf_1_<?php echo esc_attr( $custom_field ); ?>" type="radio"
+						       name="cf[<?php echo esc_attr( $custom_field ); ?>]"
+						       value="copy" <?php checked( $translation_preference, 'copy' ); ?>/>
+					</td>
+					<td title="<?php esc_attr_e( "Copy once", 'wpml-compatibility-test-tools' ); ?>">
+						<input id="cf_2_<?php echo esc_attr( $custom_field ); ?>" type="radio"
+						       name="cf[<?php echo esc_attr( $custom_field ); ?>]" value="copy-once"/>
+					</td>
+					<td title="<?php esc_attr_e( "Translate", 'wpml-compatibility-test-tools' ); ?>">
+						<input id="cf_3_<?php echo esc_attr( $custom_field ); ?>" type="radio"
+						       name="cf[<?php echo esc_attr( $custom_field ); ?>]"
+						       value="translate" <?php checked( $translation_preference, 'translate' ); ?>/>
+					</td>
+					<td>
+						<?php
+						global $wpdb;
+
+						$value = $wpdb->get_var( $wpdb->prepare( "SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = %s LIMIT 1", $custom_field ) );
+
+						// Define the maximum number of characters to display
+						$maxLength = 50;
+
+						// If the value length is greater than the defined maximum length,
+						// cut it down and append '...' to indicate that it's truncated
+						if ( strlen( $value ) > $maxLength ) {
+							$value = substr( $value, 0, $maxLength ) . "...";
+						} elseif ( empty( $value ) ) {
+							$value = 'N/A';
+						}
+
+						?><code><?php echo $value; ?></code>
+					</td>
+				</tr>
+			<?php endforeach; ?>
+			</tbody>
+			<tfoot>
+			<tr>
+				<th><?php esc_html_e( 'Custom fields', 'wpml-compatibility-test-tools' ); ?></th>
+				<th><?php esc_html_e( "Don't translate", 'wpml-compatibility-test-tools' ); ?></th>
+				<th><?php esc_html_e( "Copy", 'wpml-compatibility-test-tools' ); ?></th>
+				<th><?php esc_html_e( "Copy once", 'wpml-compatibility-test-tools' ); ?></th>
+				<th><?php esc_html_e( "Translate", 'wpml-compatibility-test-tools' ); ?></th>
+				<th><?php esc_html_e( "Sample", 'wpml-compatibility-test-tools' ); ?></th>
+			</tr>
+			</tfoot>
+		</table>
+		<?php wp_nonce_field( 'wpml_cf_nonce', 'wpml_cf_nonce' ); ?>
+		<input type="hidden" name="action" value="wpml_cf_generate_xml"/>
+		<br>
+		<button class="button-primary"
+		        type="submit"><?php esc_html_e( 'Generate XML', 'wpml-compatibility-test-tools' ); ?></button>
+		<button class="button-primary" id="copy-xml" type="button"
+		        disabled><?php esc_html_e( 'Copy XML', 'wpml-compatibility-test-tools' ); ?></button>
+	</form>
+	<br>
+	<textarea id="xml-output" readonly style="width: 90%; min-height: 300px; background-color: #fff"></textarea>
+	<?php else: ?>
+		<thead>
+		<tr>
+			<th colspan="5"><?php esc_html_e( 'Custom Fields', 'wpml-compatibility-test-tools' ); ?></th>
+		</tr>
+		</thead>
+		<tbody class="wctt">
+		<tr>
+			<td colspan="5"><?php esc_html_e( 'It looks like all custom fields have their translation preferences.', 'wpml-compatibility-test-tools' ); ?></td>
+		</tr>
+		</tbody>
+	<?php endif; ?>
+	</table>
+
+
+</div>

--- a/multilingual-tools.php
+++ b/multilingual-tools.php
@@ -24,6 +24,7 @@ require_once WPML_CTT_PATH . '/inc/class-mltools-shortcode-attribute-filter.php'
 require_once WPML_CTT_PATH . '/inc/class-mltools-shortcode-config.php';
 require_once WPML_CTT_PATH . '/inc/class-mltools-shortcode-wpml-config-parser.php';
 require_once WPML_CTT_PATH . '/inc/class-mltools-xml-helper.php';
+require_once WPML_CTT_PATH . '/inc/class-mltools-custom-fields-translation.php';
 
 // Disable informations about ICanLocalize.
 if (!defined('ICL_DONT_PROMOTE')) {

--- a/res/js/mt-script.js
+++ b/res/js/mt-script.js
@@ -331,4 +331,36 @@ jQuery(function () {
             return true;
     }
 
+    jQuery('#wpml-cf-form').on('submit', function (e) {
+        e.preventDefault();
+
+        var data = jQuery(this).serialize();
+
+        jQuery.post(ajaxurl, data, function (response) {
+            // Decode the response before setting it as the textarea value
+            var decodedResponse = jQuery('<div/>').html(response).text();
+            jQuery('#xml-output').text(decodedResponse);
+
+            // Enable the copy button if the textarea is not empty
+            if (decodedResponse.trim() !== '') {
+                jQuery('#copy-xml').prop('disabled', false);
+            }
+        });
+    });
+
+    jQuery('#copy-xml').on('click', function (e) {
+        e.preventDefault();
+
+        var xmlOutput = document.getElementById('xml-output');
+        xmlOutput.select();
+
+        try {
+            // Copy the selected text to the clipboard
+            document.execCommand('copy');
+            alert('XML copied to clipboard!');
+        } catch (err) {
+            console.log('Oops, unable to copy');
+        }
+    });
+
 });


### PR DESCRIPTION
Adding new menu item under Multilingual Tools  → Custom Fields Translation that allows you to manage the translation preferences for custom fields in your WordPress site. It provides a user-friendly interface to review and update the translation preferences for each custom field.

With this addition, you can easily specify whether a custom field should be translated, copied, or ignored during the translation process. The new feature analyzes the custom field values and suggests a translation preference based on various criteria such as numeric values, date strings, specific strings, and more.