### PR TITLE
[compdev-247] Make sure `is_plugin_active` exists in `MLTools_Elementor_Config_Generator`

### DIFF
--- a/inc/class-mltools-elementor-config-generator.php
+++ b/inc/class-mltools-elementor-config-generator.php
@@ -4,6 +4,10 @@ class MLTools_Elementor_Config_Generator
 {
 
     public function __construct() {
+        if ( ! function_exists( 'is_plugin_active' ) ) {
+            include_once ABSPATH . 'wp-admin/includes/plugin.php';
+        }
+
         if ( class_exists( 'Sitepress' ) && is_plugin_active( 'elementor/elementor.php' ) ) {
             add_action( 'add_meta_boxes', array( $this, 'register_meta_box' ) );
         }


### PR DESCRIPTION
This was causing an issue when activating the plugin with CLI.

https://onthegosystems.myjetbrains.com/youtrack/issue/compdev-247/