### PR TITLE
Fixed issue with class-mltools-elementor-config-generator.php

### DIFF
--- a/inc/class-mltools-elementor-config-generator.php
+++ b/inc/class-mltools-elementor-config-generator.php
@@ -60,7 +60,7 @@ class MLTools_Elementor_Config_Generator
         $widgets = array();
 
         foreach ( $elements as $element ) {
-            if ( $element->elType === 'widget' ) {
+            if ( $element->elType === 'widget' && isset( $element->settings ) && is_object( $element->settings ) )  {
                 $widgetType                    = $element->widgetType;
                 $settings                      = (array) get_object_vars( $element->settings );
 


### PR DESCRIPTION
Fixed the following error:
PHP Fatal error: Uncaught TypeError: get_object_vars(): Argument #1 ($object) must be of type object, array given in public_html/wp-content/plugins/multilingual-tools-master/inc/class-mltools-elementor-config-generator.php:65

For more details, see compsupp-7127