### PR TITLE
Fix `Undefined variable $date` warning in custom fields translation (#35)

### DIFF
--- a/inc/class-mltools-custom-fields-translation.php
+++ b/inc/class-mltools-custom-fields-translation.php
@@ -78,9 +78,17 @@ class MLTools_Custom_Fields_Translation {
 
 			// Check if value is numeric, a date string, or specific strings
 
+			$date        = false;
+			$date_errors = array( 'warning_count' => 0, 'error_count' => 0 );
+
 			if ( $value ) {
-				$date        = DateTime::createFromFormat( 'd-m-Y', $value );
-				$date_errors = DateTime::getLastErrors();
+				$date   = DateTime::createFromFormat( 'd-m-Y', $value );
+				$errors = DateTime::getLastErrors();
+
+				// As of PHP 8.2, DateTime::getLastErrors() returns false when there are no warnings or errors.
+				if ( is_array( $errors ) ) {
+					$date_errors = $errors;
+				}
 			}
 
 			// These values should be copied to translations
@@ -94,7 +102,6 @@ class MLTools_Custom_Fields_Translation {
 			     ( $date && $date_errors['warning_count'] == 0 && $date_errors['error_count'] == 0 ) ||
 			     in_array( $value, $copy_values ) ||
 			     is_serialized( $value ) ||
-			     null ||
 			     empty( $value ) ||
 			     // Check if the value is an email or a URL.
 			     filter_var( $value, FILTER_VALIDATE_EMAIL ) ||


### PR DESCRIPTION
**Summary**
Fixes the warning reported in #35 and a related PHP 8.2+ warning in the same block of
`MLTools_Custom_Fields_Translation::determine_translation_preference()`.

**Problem**
`$date` and `$date_errors` are assigned only inside `if ( $value )`, but the
classification condition reads them unconditionally:

```php
if ( $value ) {
    $date        = DateTime::createFromFormat( 'd-m-Y', $value );
    $date_errors = DateTime::getLastErrors();
}
...
if ( is_numeric( $value ) ||
     ( $date && $date_errors['warning_count'] == 0 && $date_errors['error_count'] == 0 ) || ...
```

When a custom field's first stored value is an **empty string**, `is_numeric('')` is
`false`, so evaluation does not short-circuit and reaches `$date`/`$date_errors` before
they are ever defined → `Warning: Undefined variable $date` (the reported issue).

A related latent bug lives on the same lines: as of **PHP 8.2**,
`DateTime::getLastErrors()` returns `false` (not an array) when there are no
warnings/errors, so for any **valid date** value the condition does `false['warning_count']`
→ `Warning: Trying to access array offset on value of type bool`.

**Reproduction**
1. On PHP 8.0+ with `WP_DEBUG` on, open the Custom Fields helper with a field whose first stored value is an empty string → `Undefined variable $date`.
2. On PHP 8.2+, use a field whose value is a `d-m-Y` date (e.g. `25-12-2023`) → `Trying to access array offset on value of type bool` (×2).

**Changes**
1. Initialize `$date = false` and `$date_errors = array( 'warning_count' => 0, 'error_count' => 0 )` **before** the value check, so both are always defined.
2. Guard `DateTime::getLastErrors()` with `is_array()` and only override the default on a real array — safe across PHP < 8.2 and ≥ 8.2.
3. Remove the stray `null ||` term from the condition (dead code — always falsy).

**Testing**
Isolated the conditional and ran it on PHP 8.4 with `error_reporting(E_ALL)`:
- Before: empty value → `Undefined variable $date`; `25-12-2023` → `Trying to access array offset on false` (×2).
- After: no warnings on either input.
- Classification behavior unchanged: empty / numeric / date / serialized / email / URL / hash-like → `copy`; plain text → `translate`.

**Risk**
Behavior-preserving. Only variable initialization and a dead term change; no change to
how any value is classified.

Closes #35